### PR TITLE
fix(ci): use transport directory in run-transport-interop action

### DIFF
--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ""
   test-root:
-    description: "Path to the transport-interop folder"
+    description: "Path to the transport folder"
     required: true
   update-readme:
     description: "Whether to update the README.md file with the new dashboard"
@@ -69,11 +69,11 @@ runs:
         echo "PUSH_CACHE=true" >> $GITHUB_ENV
 
     # This depends on where this file is within this repository. This walks up
-    # from here to the transport-interop folder
+    # from here to the transport folder
     - name: Find working directory
       shell: bash
       run: |
-        WORK_DIR=$(realpath "$GITHUB_ACTION_PATH/../../../transport-interop")
+        WORK_DIR=$(realpath "$GITHUB_ACTION_PATH/../../../transport")
         echo "WORK_DIR=$WORK_DIR" >> $GITHUB_OUTPUT
       id: find-workdir
 


### PR DESCRIPTION
## Summary
- Migrate the action-path fix from `libp2p/test-plans#801` for `.github/actions/run-transport-interop-test/action.yml`.
- Update the composite action working-directory path from `transport-interop` to `transport`.
- Keep this as a standalone PR so it can be reviewed/merged independently from the go-v0.47 migration payload.

## Context
- Original PR: https://github.com/libp2p/test-plans/pull/801
- Companion migration PR in this repo: https://github.com/libp2p/unified-testing/pull/34
- Migration guidance: https://github.com/libp2p/unified-testing/discussions/21

## Test plan
- [ ] Validate the composite action resolves `WORK_DIR` correctly on CI.
- [ ] Confirm no behavior changes outside path resolution.

Made with [Cursor](https://cursor.com)