### PR TITLE
fix: handle SIGTERM (exit 143) when listener exits before dialer

### DIFF
--- a/hole-punch/lib/run-single-test.sh
+++ b/hole-punch/lib/run-single-test.sh
@@ -521,8 +521,8 @@ else
         echo "" >> "${LOG_FILE}"
         log_error "Test timed out after ${TEST_TIMEOUT} seconds"
     else
-        EXIT_CODE=1
-        log_error "  ✗ Test failed"
+        EXIT_CODE="${TEST_EXIT}"
+        log_error "  ✗ Test failed (exit code ${TEST_EXIT})"
     fi
 fi
 
@@ -544,6 +544,21 @@ else
   # Normal: extract YAML from dialer logs
   # Match only measurement sections and their fields (not logging output)
   DIALER_YAML=$(echo "${DIALER_LOGS}" | grep -E "dialer.*\| (latency:|  (handshake_plus_one_rtt|ping_rtt|unit):)" | sed 's/^.*| //' || echo "")
+fi
+
+# Handle exit code 143 (SIGTERM): When the listener exits before the dialer,
+# docker-compose's --abort-on-container-exit sends SIGTERM to the dialer.
+# Slow-to-shutdown implementations (e.g. JVM) exit with 143 even though the
+# test completed successfully. If we have valid measurement data, treat as pass.
+# See: https://github.com/libp2p/unified-testing/issues/16
+if [ "${EXIT_CODE}" -eq 143 ] && [ -n "${DIALER_YAML}" ]; then
+  log_message "  → Dialer received SIGTERM (exit 143) but produced valid results — treating as pass"
+  EXIT_CODE=0
+fi
+
+# Normalize any remaining non-zero exit code to 1 for consistent status reporting
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  EXIT_CODE=1
 fi
 
 # Save complete result to individual file

--- a/perf/lib/run-single-test.sh
+++ b/perf/lib/run-single-test.sh
@@ -215,8 +215,8 @@ else
         echo "" >> "${LOG_FILE}"
         log_error "Test timed out after ${TEST_TIMEOUT} seconds"
     else
-        EXIT_CODE=1
-        log_error "  ✗ Test failed"
+        EXIT_CODE="${TEST_EXIT}"
+        log_error "  ✗ Test failed (exit code ${TEST_EXIT})"
     fi
 fi
 
@@ -238,6 +238,21 @@ else
   # Normal: extract YAML from dialer logs
   # Match only measurement sections and their fields (not logging output)
   DIALER_YAML=$(echo "${DIALER_LOGS}" | grep -E "dialer.*\| (upload:|download:|latency:|  (iterations|min|q1|median|q3|max|outliers|samples|unit):)" | sed 's/^.*| //' || echo "")
+fi
+
+# Handle exit code 143 (SIGTERM): When the listener exits before the dialer,
+# docker-compose's --abort-on-container-exit sends SIGTERM to the dialer.
+# Slow-to-shutdown implementations (e.g. JVM) exit with 143 even though the
+# test completed successfully. If we have valid measurement data, treat as pass.
+# See: https://github.com/libp2p/unified-testing/issues/16
+if [ "${EXIT_CODE}" -eq 143 ] && [ -n "${DIALER_YAML}" ]; then
+  log_message "  → Dialer received SIGTERM (exit 143) but produced valid results — treating as pass"
+  EXIT_CODE=0
+fi
+
+# Normalize any remaining non-zero exit code to 1 for consistent status reporting
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  EXIT_CODE=1
 fi
 
 # Save complete result to individual file

--- a/transport/lib/run-single-test.sh
+++ b/transport/lib/run-single-test.sh
@@ -131,6 +131,7 @@ ${LISTENER_ENV}
   dialer:
     image: "${DIALER_IMAGE}"
     container_name: ${TEST_SLUG}_dialer
+    init: true
     depends_on:
       - listener
       - proxy-${TEST_KEY}
@@ -165,6 +166,7 @@ ${LISTENER_ENV}
   dialer:
     image: "${DIALER_IMAGE}"
     container_name: ${TEST_SLUG}_dialer
+    init: true
     depends_on:
       - listener
     networks:
@@ -198,8 +200,8 @@ else
         echo "" >> "${LOG_FILE}"
         log_error "Test timed out after ${TEST_TIMEOUT} seconds"
     else
-        EXIT_CODE=1
-        log_error "  ✗ Test failed"
+        EXIT_CODE="${TEST_EXIT}"
+        log_error "  ✗ Test failed (exit code ${TEST_EXIT})"
     fi
 fi
 
@@ -230,6 +232,21 @@ if [ -n "${DIALER_YAML}" ]; then
   if echo "${DIALER_YAML}" | head -1 | grep -q '^-'; then
     DIALER_YAML=""
   fi
+fi
+
+# Handle exit code 143 (SIGTERM): When the listener exits before the dialer,
+# docker-compose's --abort-on-container-exit sends SIGTERM to the dialer.
+# Slow-to-shutdown implementations (e.g. JVM) exit with 143 even though the
+# test completed successfully. If we have valid measurement data, treat as pass.
+# See: https://github.com/libp2p/unified-testing/issues/16
+if [ "${EXIT_CODE}" -eq 143 ] && [ -n "${DIALER_YAML}" ]; then
+  log_message "  → Dialer received SIGTERM (exit 143) but produced valid results — treating as pass"
+  EXIT_CODE=0
+fi
+
+# Normalize any remaining non-zero exit code to 1 for consistent status reporting
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  EXIT_CODE=1
 fi
 
 # Save complete result to individual file


### PR DESCRIPTION
## Summary
- When docker-compose's ``--abort-on-container-exit`` kills the dialer via SIGTERM after the listener exits first, slow-to-shutdown implementations  report exit code 143 even though the test completed successfully
- Added ``init: true`` to transport dialer containers for proper signal forwarding (perf and hole-punch already had it)
- Preserved actual exit code instead of hardcoding 1, then recover from 143 if valid measurement data exists
- Applied consistently across all 3 test suites (transport, perf, hole-punch)

## Test plan
- [x] ``bash -n`` syntax validation on all 3 modified files
- [x] Transport tests: 4/4 pass (rust-v0.56, tcp)
- [x] Perf tests: 12/13 pass (only pre-existing webrtc-direct failure)
- [x] No regressions introduced

Fixes #16