### PR TITLE
fix results upload

### DIFF
--- a/.github/workflows/daily-full-interop.yml
+++ b/.github/workflows/daily-full-interop.yml
@@ -404,6 +404,7 @@ jobs:
 
       - name: Download transport test results
         if: needs.run-transport-full.result != 'skipped'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: transport-test-results-*
@@ -412,6 +413,7 @@ jobs:
 
       - name: Download hole-punch test results
         if: needs.run-hole-punch-full.result != 'skipped'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: hole-punch-test-results-*
@@ -420,6 +422,7 @@ jobs:
 
       - name: Download perf test results
         if: needs.run-perf-full.result != 'skipped'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: perf-test-results-*
@@ -456,7 +459,6 @@ jobs:
             echo "--- First test entry ---"
             yq eval '.testResults[0]' "$PERF_YAML" 2>/dev/null || echo "No test results found"
           fi
-
 
       - name: Find result directories and prepare merge
         id: find-results
@@ -570,7 +572,7 @@ jobs:
           set -euo pipefail
 
           RESULTS_FILE="/tmp/merged-results/daily-full-interop.yml"
-          BUCKET="test-plans-results"
+          BUCKET="results"
           ENDPOINT="https://s3.filebase.com"
           DATE_STAMP=$(date -u +"%Y-%m-%d")
 

--- a/lib/merge-interop-results.sh
+++ b/lib/merge-interop-results.sh
@@ -129,7 +129,20 @@ EOF
 
 else
     echo "  No transport results found"
-    echo "transport: null" >> "$OUTPUT_FILE"
+    cat >> "$OUTPUT_FILE" << 'TRANSPORT_EOF'
+transport:
+  metadata:
+    test-pass: ""
+    started-at: ""
+    completed-at: ""
+    duration: ""
+  summary:
+    total: 0
+    passed: 0
+    failed: 0
+  results:
+    []
+TRANSPORT_EOF
 fi
 
 # Process Hole-punch results
@@ -183,7 +196,20 @@ EOF
 
 else
     echo "  No hole-punch results found"
-    echo "hole-punch: null" >> "$OUTPUT_FILE"
+    cat >> "$OUTPUT_FILE" << 'HOLEPUNCH_EOF'
+hole-punch:
+  metadata:
+    test-pass: ""
+    started-at: ""
+    completed-at: ""
+    duration: ""
+  summary:
+    total: 0
+    passed: 0
+    failed: 0
+  results:
+    []
+HOLEPUNCH_EOF
 fi
 
 # Process Perf results
@@ -285,7 +311,25 @@ EOF
 
 else
     echo "  No perf results found"
-    echo "perf: null" >> "$OUTPUT_FILE"
+    cat >> "$OUTPUT_FILE" << 'PERF_EOF'
+perf:
+  metadata:
+    test-pass: ""
+    started-at: ""
+    completed-at: ""
+    duration: ""
+  summary:
+    baseline-total: 0
+    baseline-passed: 0
+    baseline-failed: 0
+    main-total: 0
+    main-passed: 0
+    main-failed: 0
+  baselines:
+    []
+  results:
+    []
+PERF_EOF
 fi
 
 echo ""


### PR DESCRIPTION
This fixes the results merging and uploading by making it skip missing test results.

Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>
