### PR TITLE
feat: python perf - yamux window auto-tuning

### DIFF
--- a/perf/images.yaml
+++ b/perf/images.yaml
@@ -103,19 +103,9 @@ implementations:
   - id: python-v0.x
     source:
       type: github
-      repo: libp2p/py-libp2p
-      commit: ca470efdaf4df982d4e3844d86a515eb18efca7a
+      repo: asabya/py-libp2p
+      commit: 9a9a4a62a50457394ad7eac315150f9ee45510eb
       dockerfile: interop/perf/Dockerfile
     transports: [tcp, ws]
     secureChannels: [noise, tls]
     muxers: [yamux, mplex]
-  # Local python config (same Dockerfile; context = repo root = images/python/0.x/py-libp2p)
-  #- id: python-v0.x
-  #  source:
-  #    type: local
-  #    path: images/python/0.x/py-libp2p
-  #    dockerfile: interop/perf/Dockerfile
-    # transports: [quic-v1, tcp, ws]
-  #  transports: [tcp, ws]
-  #  secureChannels: [noise, tls]
-  #  muxers: [yamux, mplex]

--- a/perf/images.yaml
+++ b/perf/images.yaml
@@ -104,7 +104,7 @@ implementations:
     source:
       type: github
       repo: asabya/py-libp2p
-      commit: 9a9a4a62a50457394ad7eac315150f9ee45510eb
+      commit: 112b7cf7f65d7f47dc7f655d8fe572b0f3f3b820
       dockerfile: interop/perf/Dockerfile
     transports: [tcp, ws]
     secureChannels: [noise, tls]

--- a/perf/images.yaml
+++ b/perf/images.yaml
@@ -104,7 +104,7 @@ implementations:
     source:
       type: github
       repo: asabya/py-libp2p
-      commit: 112b7cf7f65d7f47dc7f655d8fe572b0f3f3b820
+      commit: 7223cd32884e8a6426268c629e562e9278cd2219
       dockerfile: interop/perf/Dockerfile
     transports: [tcp, ws]
     secureChannels: [noise, tls]


### PR DESCRIPTION
## Summary

- Point `python-v0.x` perf image at `asabya/py-libp2p` with yamux receive window auto-tuning (256KB → 16MB)
- Remove commented-out local python config block from `images.yaml`

## Changes

**`perf/images.yaml`**: Switch python-v0.x source from `libp2p/py-libp2p` to `asabya/py-libp2p` (commit `9a9a4a6`) which includes yamux window auto-tuning. Clean up commented-out local config.

## Test plan

- [x] Verify perf Docker image builds successfully from the new commit
- [x] Run python-v0.x perf tests (tcp + ws, noise + tls, yamux + mplex)
- [x] Confirm throughput improvement with auto-tuned yamux windows