### PR TITLE
fix(transport): enable TLS in dotnet transport interop tests

### DIFF
--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -270,10 +270,10 @@ implementations:
     source:
       type: github
       repo: NethermindEth/dotnet-libp2p
-      commit: e46c0227b3916552162fde18f258e22790429d2f
+      commit: 960726885ca467fd2205bbb0fa4821a34b9e8f31
       dockerfile: src/samples/transport-interop/Dockerfile
     transports: [tcp, quic-v1]
-    secureChannels: [noise]
+    secureChannels: [tls, noise]
     muxers: [yamux]
 
   # Zig implementation


### PR DESCRIPTION
It  enables TLS support for the .NET transport interoperability test cases by making the .NET TLS stack behave consistently with other libp2p implementations (Go/Rust/JS). It also updates the transport-interop runner so SECURE_CHANNEL=tls works end-to-end.

**Key changes**

-  Added TLS mode support to the dotnet transport interop sample (SECURE_CHANNEL=tls)

-  Ensured the dotnet TLS client sends the libp2p client certificate reliably (mutual TLS)

-  Avoid sending IP-based SNI (matches other libp2p implementations)

-  Updated certificate generation to use a compatible validity period (prevents ASN.1 parsing failures)

-  Included TLS in the default protocol stack used by dotnet peers for interop testing