### PR TITLE
transport: add eth-p2p-z-v0.0.2 (epoll backend, fixes seccomp failure)

### DIFF
--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -31,11 +31,11 @@ test-aliases:
   - alias: "zig"
     value: "zig-v0.0.1"
   - alias: "eth-p2p"
-    value: "eth-p2p-z-v0.0.1"
+    value: "eth-p2p-z-v0.0.1|eth-p2p-z-v0.0.2"
   - alias: "lua"
     value: "lua-v0.1.0"
   - alias: "failing" # everything except rust-v0.56 and js and python-v0.x implementations as of 25 Jan 2026
-    value: "~browsers|go-v0.38|go-v0.39|go-v0.40|go-v0.41|go-v0.42|go-v0.43|go-v0.44|go-v0.45|~nim|~jvm|~c|~dotnet|~zig|~eth-p2p|rust-v0.53|rust-v0.54|rust-v0.55|lua-v0.1.0 x python-v0.x"
+    value: "~browsers|go-v0.38|go-v0.39|go-v0.40|go-v0.41|go-v0.42|go-v0.43|go-v0.44|go-v0.45|~nim|~jvm|~c|~dotnet|~zig|eth-p2p-z-v0.0.1|rust-v0.53|rust-v0.54|rust-v0.55|lua-v0.1.0 x python-v0.x"
 
 implementations:
   # Rust implementations
@@ -314,6 +314,16 @@ implementations:
     secureChannels: []
     muxers: []
     legacy: true
+
+  - id: eth-p2p-z-v0.0.2
+    source:
+      type: github
+      repo: zen-eth/eth-p2p-z
+      commit: 983846e42a4be47500e4c9f9194efa1243f23ba8
+      dockerfile: interop/transport/Dockerfile
+    transports: [quic-v1]
+    secureChannels: []
+    muxers: []
 
   # Browser implementations (require local build)
   # Note: Browser images are built from js implementations

--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -319,12 +319,11 @@ implementations:
     source:
       type: github
       repo: zen-eth/eth-p2p-z
-      commit: 983846e42a4be47500e4c9f9194efa1243f23ba8
+      commit: a59973433d15b4f2ed4f394c149766aa739d845f
       dockerfile: interop/transport/Dockerfile
     transports: [quic-v1]
     secureChannels: []
     muxers: []
-    legacy: true
 
   # Browser implementations (require local build)
   # Note: Browser images are built from js implementations

--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -324,6 +324,7 @@ implementations:
     transports: [quic-v1]
     secureChannels: []
     muxers: []
+    legacy: true
 
   # Browser implementations (require local build)
   # Note: Browser images are built from js implementations


### PR DESCRIPTION
## What

Adds `eth-p2p-z-v0.0.2` to the transport suite and moves it out of the `failing` alias (keeps `v0.0.1`).

## Why

`eth-p2p-z-v0.0.1` (`a517a15`) predates eth-p2p-z's epoll/seccomp fix: it builds zio's io_uring backend, which the default Docker seccomp profile blocks (`io_uring_setup` → `PermissionDenied` at startup), so it fails in the matrix — hence the `failing` alias.

`v0.0.2` (`983846e`) builds the transport interop binary on the **epoll** backend (the Dockerfile forces `-Dzio-backend=epoll`), so it starts under the default seccomp profile.

## Notes

- `repo: zen-eth/eth-p2p-z @ 983846e`, `dockerfile: interop/transport/Dockerfile`.
- `quic-v1` only (QUIC-native security + muxer), so `secureChannels`/`muxers` are empty.
