### PR TITLE
transport: bump eth-p2p-z-v0.0.2 (serve identify + all inbound connections)

### DIFF
--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -319,7 +319,7 @@ implementations:
     source:
       type: github
       repo: zen-eth/eth-p2p-z
-      commit: ac42c1fc9c44af38e4a72c5bd6722dc5e69c2b2c
+      commit: bb368b1932aca9c32bd9da74f592a5c5f1ba3bc0
       dockerfile: interop/transport/Dockerfile
     transports: [quic-v1]
     secureChannels: []

--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -319,7 +319,7 @@ implementations:
     source:
       type: github
       repo: zen-eth/eth-p2p-z
-      commit: a59973433d15b4f2ed4f394c149766aa739d845f
+      commit: f0f64b4400f56c732e45319a332163c8913f047a
       dockerfile: interop/transport/Dockerfile
     transports: [quic-v1]
     secureChannels: []

--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -319,7 +319,7 @@ implementations:
     source:
       type: github
       repo: zen-eth/eth-p2p-z
-      commit: f0f64b4400f56c732e45319a332163c8913f047a
+      commit: ac42c1fc9c44af38e4a72c5bd6722dc5e69c2b2c
       dockerfile: interop/transport/Dockerfile
     transports: [quic-v1]
     secureChannels: []


### PR DESCRIPTION
Bumps `eth-p2p-z-v0.0.2` from `a599734` to `f0f64b4`.

Changes in this range:
- The interop listener now serves the **identify** protocol (`/ipfs/id/1.0.0`); previously it answered `na`, so dialers logged a "protocol not supported" error.
- The listener serves **all inbound connections**, not just the first — a dialer may open more than one (e.g. py-libp2p opens a second connection after a successful identify exchange).

No matrix changes: `eth-p2p-z-v0.0.2` stays `quic-v1`, modern (`legacy: false`).