### PR TITLE
perf: bump eth-p2p-z-v0.0.2 to 1210874

### DIFF
--- a/perf/images.yaml
+++ b/perf/images.yaml
@@ -172,7 +172,7 @@ implementations:
     source:
       type: github
       repo: zen-eth/eth-p2p-z
-      commit: 983846e42a4be47500e4c9f9194efa1243f23ba8
+      commit: 12108747eb96eb56000cf10b21493eb4a03d50f1
       dockerfile: interop/perf/Dockerfile
     transports: [quic-v1]
     secureChannels: []


### PR DESCRIPTION
Bumps the `eth-p2p-z-v0.0.2` perf image from `983846e` to `1210874`.

What this brings in:
- Larger default per-stream outbound buffer (128 KB queue / 64 KB quantum) — fewer cross-fiber handoffs on the send path.
- Perf binary uses the library default transport config (no per-binary override).
- Serve identify + accept all inbound connections by default.
- cgroup-aware executor pool sizing.

No change to the perf harness contract — same `interop/perf/Dockerfile`, `quic-v1` only.