### PR TITLE
feat: transport haskell-v0.1 (libp2p-hs)

### DIFF
--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -5,7 +5,7 @@
 # Usage: --test-select "~browsers" or --test-ignore "!~browsers"
 test-aliases:
   - alias: "all"
-    value: "~browsers|~rust|~go|~python|~js|~nim|~jvm|~c|~dotnet|~zig|~eth-p2p|~lua"
+    value: "~browsers|~rust|~go|~python|~js|~nim|~jvm|~c|~dotnet|~zig|~eth-p2p|~lua|~haskell"
   - alias: "browsers"
     value: "chromium-rust-v0.53|chromium-rust-v0.54|chromium-rust-v0.56|chromium-js-v1.x|chromium-js-v2.x|firefox-js-v1.x|firefox-js-v2.x|webkit-js-v1.x|webkit-js-v2.x"
   - alias: "rust-browsers"
@@ -22,6 +22,8 @@ test-aliases:
     value: "js-v1.x|js-v2.x|js-v3.x"
   - alias: "nim"
     value: "nim-v2.2.0"
+  - alias: "haskell"
+    value: "haskell-v0.1"
   - alias: "jvm"
     value: "jvm-v1.2"
   - alias: "c"
@@ -263,6 +265,17 @@ implementations:
     transports: [tcp, ws, quic-v1]
     secureChannels: [noise]
     muxers: [mplex, yamux]
+
+  # Haskell implementation
+  - id: haskell-v0.1
+    source:
+      type: github
+      repo: adust09/libp2p-hs
+      commit: a54593aeffa2d428a83abfc26c3fb3afdd9948fa
+      dockerfile: Dockerfile
+    transports: [tcp]
+    secureChannels: [noise]
+    muxers: [yamux]
 
   # JVM implementation
   - id: jvm-v1.2

--- a/transport/images.yaml
+++ b/transport/images.yaml
@@ -271,7 +271,7 @@ implementations:
     source:
       type: github
       repo: adust09/libp2p-hs
-      commit: a54593aeffa2d428a83abfc26c3fb3afdd9948fa
+      commit: 87b4b0b7a01cddefa294a651dc98a872a21bf66f
       dockerfile: Dockerfile
     transports: [tcp]
     secureChannels: [noise]


### PR DESCRIPTION
Add `haskell` to the transport interop tests.

[libp2p-hs](https://github.com/adust09/libp2p-hs) is a Haskell implementation of the libp2p stack (TCP, Noise XX, Yamux, Identify, Ping, Kademlia DHT, AutoNAT, Circuit Relay v2, DCUtR, GossipSub).

## Test app

The test app conforms to the contract in `docs/write-a-transport-test-app.md`:

- Reads `IS_DIALER`, `REDIS_ADDR`, `TEST_KEY`, `TRANSPORT`, `SECURE_CHANNEL`, `MUXER`, `LISTENER_IP`, `DEBUG`
- Listener `SET`s `<TEST_KEY>_listener_multiaddr`; dialer polls with `GET`
- Listener runs until the runner shuts it down
- All logging goes to stderr; stdout carries only the YAML result
- Reports `latency: { handshake_plus_one_rtt, ping_rtt, unit: ms }`

The `Dockerfile` is at the repository root and builds with the repo root as the build context, matching `docker build -f <clone>/Dockerfile <clone>`.

## Capabilities

`transports: [tcp]`, `secureChannels: [noise]`, `muxers: [yamux]`. Other transports (QUIC, WebSocket) are not implemented yet; further entries will follow as they land.

## Validation

The implementation is exercised against `go-libp2p` in both directions (hs dialer x go listener, go dialer x hs listener) in the project's own CI, using the same contract this PR registers. Cross-testing against the other implementations in this matrix has not been done locally — happy to adjust the `failing` alias if the first upstream run turns up broken pairs.

Note: the image is a GHC build and takes roughly 10 minutes from cold. Let me know if that is a problem for the test pass budget and I will look at slimming it down.